### PR TITLE
replace cosmwasm_storage with cw_storage_plus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,10 +38,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
-name = "base64"
-version = "0.13.1"
+name = "base16ct"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "bnum"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "845141a4fade3f790628b7daaaa298a25b204fb28907eb54febe5142db6ce653"
+checksum = "128a44527fc0d6abf05f9eda748b9027536e12dff93f5acc8449f51583309350"
 
 [[package]]
 name = "byteorder"
@@ -115,22 +115,22 @@ checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e272708a9745dad8b591ef8a718571512130f2b39b33e3d7a27c558e3069394"
+checksum = "1ca101fbf2f76723711a30ea3771ef312ec3ec254ad021b237871ed802f9f175"
 dependencies = [
  "digest 0.10.7",
  "ed25519-zebra",
- "k256",
+ "k256 0.13.1",
  "rand_core 0.6.4",
  "thiserror",
 ]
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "296db6a3caca5283425ae0cf347f4e46999ba3f6620dbea8939a0e00347831ce"
+checksum = "c73d2dd292f60e42849d2b07c03d809cf31e128a4299a805abd6d24553bcaaf5"
 dependencies = [
  "syn 1.0.109",
 ]
@@ -161,11 +161,11 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5e05a95fd2a420cca50f4e94eb7e70648dac64db45e90403997ebefeb143bd"
+checksum = "2a44d3f9c25b2f864737c6605a98f2e4675d53fd8bbc7cf4d7c02475661a793d"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "bnum",
  "cosmwasm-crypto",
  "cosmwasm-derive",
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "800aaddd70ba915e19bf3d2d992aa3689d8767857727fdd3b414df4fd52d2aa1"
+checksum = "ab544dfcad7c9e971933d522d99ec75cc8ddfa338854bb992b092e11bcd7e818"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -203,6 +203,18 @@ name = "crypto-bigint"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740fe28e594155f10cfc383984cbefd529d7396050557148f79cb0f621204124"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
@@ -245,7 +257,7 @@ dependencies = [
  "cw-utils",
  "derivative",
  "itertools",
- "k256",
+ "k256 0.11.6",
  "prost 0.9.0",
  "schemars",
  "serde",
@@ -303,6 +315,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,6 +351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -345,10 +368,24 @@ version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
- "der",
- "elliptic-curve",
- "rfc6979",
- "signature",
+ "der 0.6.1",
+ "elliptic-curve 0.12.3",
+ "rfc6979 0.3.1",
+ "signature 1.6.4",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4b1e0c257a9e9f25f90ff76d7a68360ed497ee519c8e428d1825ef0000799d4"
+dependencies = [
+ "der 0.7.8",
+ "digest 0.10.7",
+ "elliptic-curve 0.13.5",
+ "rfc6979 0.4.0",
+ "signature 2.1.0",
+ "spki 0.7.2",
 ]
 
 [[package]]
@@ -378,16 +415,35 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
- "base16ct",
- "crypto-bigint",
- "der",
+ "base16ct 0.1.1",
+ "crypto-bigint 0.4.9",
+ "der 0.6.1",
  "digest 0.10.7",
- "ff",
+ "ff 0.12.1",
  "generic-array",
- "group",
- "pkcs8",
+ "group 0.12.1",
+ "pkcs8 0.9.0",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.3.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b"
+dependencies = [
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.3",
+ "digest 0.10.7",
+ "ff 0.13.0",
+ "generic-array",
+ "group 0.13.0",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "sec1 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -397,6 +453,16 @@ name = "ff"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
@@ -416,6 +482,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -435,7 +502,18 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
- "ff",
+ "ff 0.12.1",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff 0.13.0",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -492,9 +570,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
 dependencies = [
  "cfg-if",
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.14.8",
+ "elliptic-curve 0.12.3",
  "sha2 0.10.7",
+]
+
+[[package]]
+name = "k256"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
+dependencies = [
+ "cfg-if",
+ "ecdsa 0.16.8",
+ "elliptic-curve 0.13.5",
+ "once_cell",
+ "sha2 0.10.7",
+ "signature 2.1.0",
 ]
 
 [[package]]
@@ -530,8 +622,18 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
- "der",
- "spki",
+ "der 0.6.1",
+ "spki 0.6.0",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der 0.7.8",
+ "spki 0.7.2",
 ]
 
 [[package]]
@@ -638,7 +740,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d216752a4c37d7bc39ee1d397f6500fa92cf1c191c60b501038aa98cafa07c69"
 dependencies = [
- "base64 0.21.2",
+ "base64",
  "chrono",
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -678,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "restricted-marker-transfer"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -702,9 +804,19 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
- "crypto-bigint",
+ "crypto-bigint 0.4.9",
  "hmac",
  "zeroize",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
 ]
 
 [[package]]
@@ -749,10 +861,24 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.1.1",
+ "der 0.6.1",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct 0.2.0",
+ "der 0.7.8",
+ "generic-array",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -858,13 +984,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "spki"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+dependencies = [
+ "base64ct",
+ "der 0.7.8",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,16 +180,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cosmwasm-storage"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab544dfcad7c9e971933d522d99ec75cc8ddfa338854bb992b092e11bcd7e818"
-dependencies = [
- "cosmwasm-std",
- "serde",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,7 +774,6 @@ version = "0.3.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cosmwasm-storage",
  "cw-multi-test",
  "cw-storage-plus",
  "cw2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63c337e097a089e5b52b5d914a7ff6613332777f38ea6d9d36e1887cd0baa72e"
+checksum = "6ce34a08020433989af5cc470104f6bd22134320fe0221bd8aeb919fd5ec92d5"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -150,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "766cc9e7c1762d8fc9c0265808910fcad755200cd0e624195a491dd885a61169"
+checksum = "96694ec781a7dd6dea1f968a2529ade009c21ad999c88b5f53d6cc495b3b96f7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -792,6 +792,7 @@ dependencies = [
  "provwasm-mocks",
  "provwasm-std",
  "schemars",
+ "semver",
  "serde",
  "serde_json",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ provwasm-std = { version = "2.0.0" }
 cw-storage-plus = "=1.1.0"
 cw2 = "1.1.0"
 schemars = "0.8"
+semver = "1.0.16"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0.64"
 thiserror = { version = "1.0" }
@@ -53,6 +54,6 @@ uuid = { version= "0.8.2" }
 
 [dev-dependencies]
 prost = {version = "0.11.0", default-features = false}
-cosmwasm-schema = { version = "1.3.1" }
+cosmwasm-schema = { version = "=1.4.0" }
 provwasm-mocks = { version = "2.0.0" }
 cw-multi-test = "0.16.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "restricted-marker-transfer"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Jason Talis <jtalis@figure.com>"]
 edition = "2018"
 
@@ -40,10 +40,10 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
-cosmwasm-std = { version = "1.3.1" }
-cosmwasm-storage = { version = "1.3.1" }
+cosmwasm-std = { version = "=1.4.0" }
+cosmwasm-storage = { version = "1.4.0" }
 provwasm-std = { version = "2.0.0" }
-cw-storage-plus = "1.1.0"
+cw-storage-plus = "=1.1.0"
 cw2 = "1.1.0"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 
 [dependencies]
 cosmwasm-std = { version = "=1.4.0" }
-cosmwasm-storage = { version = "1.4.0" }
 provwasm-std = { version = "2.0.0" }
 cw-storage-plus = "=1.1.0"
 cw2 = "1.1.0"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This contract facilitates the transfer of restricted coin between addresses.
 
 ## Background
 
-As a holder of a restricted marker, there is no way to transfer those coins without being granted marker transfer permissions or having an account with the permissions to initiate the transfer. This contract allows an account that holds a restricted marker to initiate a transfer that can then be approved or rejected by a marker admin. 
+As a holder of a restricted marker, there is no way to transfer those coins without being granted marker transfer permissions or having an account with the permissions to initiate the transfer. This contract allows an account that holds a restricted marker to initiate a transfer that can then be approved or rejected by a marker admin.
 
 ## Assumptions
 
@@ -36,11 +36,11 @@ for details.
 
 ## Blockchain Quickstart
 
-Checkout provenance v1.10.0, install the `provenanced` command and start a 4-node localnet.
+Checkout provenance v1.16.0, install the `provenanced` command and start a 4-node localnet.
 
 ```bash
 git clone https://github.com/provenance-io/provenance.git
-cd provenance && git checkout v1.10.0
+cd provenance && git checkout v1.16.0
 make install
 make localnet-start
 ```
@@ -306,6 +306,18 @@ provenanced tx wasm execute tp15fnweczx7273jc6tmuuacmkl6zk6mq8ffh8r0artxp9srdpct
     --testnet \
     --yes -o json | jq
 ```
+
+### Query transfers
+
+query all pending transfers
+```bash
+provenanced q wasm contract-state smart tp15fnweczx7273jc6tmuuacmkl6zk6mq8ffh8r0artxp9srdpctcesek7uac \
+    '{"get_all_transfers":{}}' \
+    --ascii -o json \
+    --chain-id chain-local \
+    --testnet | jq
+```
+
 ### Approve
 Now the marker admin can approve the transfer
 ```bash

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -14,7 +14,7 @@ use provwasm_std::types::provenance::marker::v1::{
 use crate::error::ContractError;
 use crate::msg::{ExecuteMsg, QueryMsg, Validate};
 use crate::state::{
-    CONFIG, get_all_transfers, get_transfer_storage, get_transfer_storage_read, Transfer,
+    get_all_transfers, get_transfer_storage, get_transfer_storage_read, Transfer, CONFIG,
 };
 
 pub const CRATE_NAME: &str = env!("CARGO_CRATE_NAME");
@@ -332,7 +332,7 @@ impl fmt::Display for Action {
 
 #[cfg(test)]
 mod tests {
-    use crate::state::{CONFIG, State};
+    use crate::state::{State, CONFIG};
     use cosmwasm_std::testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR};
     use cosmwasm_std::{coin, from_binary, Addr, CosmosMsg, Storage};
     use prost::Message;

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -14,7 +14,7 @@ use provwasm_std::types::provenance::marker::v1::{
 use crate::error::ContractError;
 use crate::msg::{ExecuteMsg, QueryMsg, Validate};
 use crate::state::{
-    config_read, get_all_transfers, get_transfer_storage, get_transfer_storage_read, Transfer,
+    CONFIG, get_all_transfers, get_transfer_storage, get_transfer_storage_read, Transfer,
 };
 
 pub const CRATE_NAME: &str = env!("CARGO_CRATE_NAME");
@@ -303,7 +303,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     msg.validate()?;
 
     match msg {
-        QueryMsg::GetContractInfo {} => to_binary(&config_read(deps.storage).load()?),
+        QueryMsg::GetContractInfo {} => to_binary(&CONFIG.load(deps.storage)?),
         QueryMsg::GetVersionInfo {} => to_binary(&cw2::get_contract_version(deps.storage)?),
         QueryMsg::GetTransfer { id: transfer_id } => {
             to_binary(&get_transfer_storage_read(deps.storage).load(transfer_id.as_bytes())?)
@@ -332,7 +332,7 @@ impl fmt::Display for Action {
 
 #[cfg(test)]
 mod tests {
-    use crate::state::{config, State};
+    use crate::state::{CONFIG, State};
     use cosmwasm_std::testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR};
     use cosmwasm_std::{coin, from_binary, Addr, CosmosMsg, Storage};
     use prost::Message;
@@ -1494,7 +1494,7 @@ mod tests {
             Ok(contract_info) => {
                 assert_eq!(
                     contract_info,
-                    to_binary(&config_read(&deps.storage).load().unwrap()).unwrap()
+                    to_binary(&CONFIG.load(&deps.storage).unwrap()).unwrap()
                 )
             }
             Err(error) => panic!("unexpected error: {:?}", error),
@@ -1625,7 +1625,7 @@ mod tests {
     }
 
     fn setup_test_base(storage: &mut dyn Storage, contract_info: &State) {
-        if let Err(error) = config(storage).save(&contract_info) {
+        if let Err(error) = CONFIG.save(storage, &contract_info) {
             panic!("unexpected error: {:?}", error)
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,9 @@ pub enum ContractError {
     #[error("Insufficient funds to complete the transfer")]
     InsufficientFunds,
 
+    #[error("Can only upgrade from same type")]
+    InvalidContractType,
+
     #[error("Invalid fields: {fields:?}")]
     InvalidFields { fields: Vec<String> },
 

--- a/src/instantiate.rs
+++ b/src/instantiate.rs
@@ -1,7 +1,7 @@
 use crate::contract::{CRATE_NAME, PACKAGE_VERSION};
 use crate::error::contract_err;
 use crate::msg::{InstantiateMsg, Validate};
-use crate::state::{CONFIG, State};
+use crate::state::{State, CONFIG};
 use crate::ContractError;
 use cosmwasm_std::{attr, entry_point, DepsMut, Env, MessageInfo, Response};
 use cw2::set_contract_version;
@@ -27,10 +27,7 @@ pub fn instantiate(
 
     // build response
     Ok(Response::new().add_attributes(vec![
-        attr(
-            "contract_info",
-            format!("{:?}", CONFIG.load(deps.storage)?),
-        ),
+        attr("contract_info", format!("{:?}", CONFIG.load(deps.storage)?)),
         attr("action", "init"),
     ]))
 }

--- a/src/instantiate.rs
+++ b/src/instantiate.rs
@@ -1,7 +1,7 @@
 use crate::contract::{CRATE_NAME, PACKAGE_VERSION};
 use crate::error::contract_err;
 use crate::msg::{InstantiateMsg, Validate};
-use crate::state::{config, config_read, State};
+use crate::state::{CONFIG, State};
 use crate::ContractError;
 use cosmwasm_std::{attr, entry_point, DepsMut, Env, MessageInfo, Response};
 use cw2::set_contract_version;
@@ -21,7 +21,7 @@ pub fn instantiate(
     }
     // Create and store config state.
     let contract_info = State { name: msg.name };
-    config(deps.storage).save(&contract_info)?;
+    CONFIG.save(deps.storage, &contract_info)?;
 
     set_contract_version(deps.storage, CRATE_NAME, PACKAGE_VERSION)?;
 
@@ -29,7 +29,7 @@ pub fn instantiate(
     Ok(Response::new().add_attributes(vec![
         attr(
             "contract_info",
-            format!("{:?}", config_read(deps.storage).load()?),
+            format!("{:?}", CONFIG.load(deps.storage)?),
         ),
         attr("action", "init"),
     ]))

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -1,12 +1,44 @@
 use cosmwasm_std::{entry_point, DepsMut, Env, Response};
 use cw2::set_contract_version;
+use cw_storage_plus::Item;
+use semver::{Version, VersionReq};
 
-use crate::contract::{CRATE_NAME, PACKAGE_VERSION};
+use crate::contract::{ CRATE_NAME, PACKAGE_VERSION};
+use crate::ContractError::{InvalidContractType, UnsupportedUpgrade};
 use crate::error::ContractError;
 use crate::msg::MigrateMsg;
+use crate::state::{CONFIG, State};
 
 #[entry_point]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    let stored_contract_version = cw2::get_contract_version(deps.storage)?;
+
+    // ensure we are migrating from an allowed contract
+    if stored_contract_version.contract != CRATE_NAME {
+        return Err(InvalidContractType);
+    }
+
+    let new_version = PACKAGE_VERSION.parse::<Version>().unwrap();
+    let current_version = stored_contract_version.version.parse::<Version>().unwrap();
+    if current_version > new_version {
+        return Err(
+            UnsupportedUpgrade { source_version: stored_contract_version.version, target_version: new_version.to_string() }
+        );
+    }
+
+    let config_migration_req = VersionReq::parse("<0.3.0").unwrap();
+
+    if config_migration_req.matches(&current_version) {
+        if CONFIG.may_load(deps.storage)?.is_none() {
+            // when migrating from cosmwasm-storage::Singleton to Item, cosmwasm_std::storage_keys::to_length_prefixed
+            // was used for the key. Hardcoding this value to copy the legacy storage
+            const LEGACY_CONFIG: Item<State> = Item::new("\0\u{6}config");
+            let state = LEGACY_CONFIG.load(deps.storage).unwrap();
+            CONFIG.save(deps.storage, &state)?;
+            LEGACY_CONFIG.remove(deps.storage)
+        }
+    }
+
     set_contract_version(deps.storage, CRATE_NAME, PACKAGE_VERSION)?;
     Ok(Response::default())
 }
@@ -22,7 +54,8 @@ mod tests {
     fn migrate_test() {
         let mut deps = mock_provenance_dependencies();
 
-        let result = cw2::set_contract_version(deps.as_mut().storage, CRATE_NAME, "v0");
+        let result = set_contract_version(deps.as_mut().storage, CRATE_NAME, "0.3.0");
+
         match result {
             Ok(..) => {}
             Err(error) => panic!("unexpected error: {:?}", error),
@@ -41,4 +74,69 @@ mod tests {
             error => panic!("failed to initialize: {:?}", error),
         }
     }
+
+    #[test]
+    fn test_migrate_legacy_config() {
+        let mut deps = mock_provenance_dependencies();
+
+        let contract_info = State { name: "rmt".into() };
+
+        // store legacy config state.
+        const LEGACY_CONFIG: Item<State> = Item::new("\0\u{6}config");
+        LEGACY_CONFIG.save(&mut deps.storage, &contract_info).unwrap();
+
+        set_contract_version(deps.as_mut().storage, CRATE_NAME, "0.2.0").unwrap();
+
+        let migrate_response = migrate(deps.as_mut(), mock_env(), MigrateMsg {});
+
+        match migrate_response {
+            Ok(..) => {}
+            error => panic!("failed to initialize: {:?}", error),
+        }
+
+        assert_eq!(contract_info, CONFIG.load(&deps.storage).unwrap())
+    }
+
+    #[test]
+    fn test_migrate_invalid_contract_type() {
+        let mut deps = mock_provenance_dependencies();
+
+        set_contract_version(deps.as_mut().storage, "other_name", "0.3.0").unwrap();
+
+        let migrate_response = migrate(deps.as_mut(), mock_env(), MigrateMsg {});
+
+        match migrate_response {
+            Ok(..) => panic!("migration should fail when the contract type is changing"),
+            Err(error) => match error {
+                InvalidContractType => {}
+                error => panic!("unexpected error: {:?}", error),
+            },
+        }
+    }
+
+    #[test]
+    fn test_migrate_invalid_version() {
+        let mut deps = mock_provenance_dependencies();
+        let current_version: String = "0.4.0".into();
+        let new_version: String = String::from(PACKAGE_VERSION);
+
+        set_contract_version(deps.as_mut().storage, CRATE_NAME, current_version).unwrap();
+
+        let migrate_response = migrate(deps.as_mut(), mock_env(), MigrateMsg {});
+
+
+
+        match migrate_response {
+            Ok(..) => panic!("migration should fail when the version is decreasing"),
+            Err(error) => match error {
+                UnsupportedUpgrade {
+                    source_version: current_version,
+                    target_version: new_version
+                } => {}
+                error => panic!("unexpected error: {:?}", error),
+            },
+        }
+    }
+
+
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,6 +1,6 @@
-use std::convert::Into;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::convert::Into;
 
 use cosmwasm_std::{Addr, Storage, Uint128};
 use cosmwasm_storage::{
@@ -68,12 +68,9 @@ mod tests {
     fn migrate_test() {
         let mut deps = mock_provenance_dependencies();
 
-        if let Err(error) = config(&mut deps.storage).save(
-        &State {
-                name: "contract_name".into(),
-            },
-        )
-        {
+        if let Err(error) = config(&mut deps.storage).save(&State {
+            name: "contract_name".into(),
+        }) {
             panic!("unexpected error: {:?}", error)
         }
 
@@ -93,16 +90,17 @@ mod tests {
             b"aaa",
             &State {
                 name: "contract_name".into(),
-            }
+            },
         ) {
             panic!("unexpected error: {:?}", error)
         }
 
         const ASKS_V1: Map<&[u8], State> = Map::new("asks");
 
-
         assert_eq!(
-            get_ask_storage_read(&mut deps.storage).load(b"aaa").unwrap(),
+            get_ask_storage_read(&mut deps.storage)
+                .load(b"aaa")
+                .unwrap(),
             ASKS_V1.load(&deps.storage, b"aaa").unwrap()
         )
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -59,7 +59,6 @@ pub fn get_all_transfers(storage: &dyn Storage) -> Vec<Transfer> {
 
 #[cfg(test)]
 mod tests {
-    use cosmwasm_std::testing::mock_env;
     use cw_storage_plus::Map;
     use provwasm_mocks::mock_provenance_dependencies;
 
@@ -78,9 +77,11 @@ mod tests {
             panic!("unexpected error: {:?}", error)
         }
 
+        const UNMIGRATED_CONFIG: Item<State> = Item::new("\0\u{6}config");
+
         assert_eq!(
             config_read(&mut deps.storage).load().unwrap(),
-            CONFIG.load(&deps.storage).unwrap()
+            UNMIGRATED_CONFIG.load(&deps.storage).unwrap()
         )
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,11 +1,15 @@
+use std::convert::Into;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{Addr, Storage, Uint128};
 use cosmwasm_storage::{
-    bucket, bucket_read, Bucket, ReadonlyBucket,
+    bucket, bucket_read, singleton, singleton_read, Bucket, ReadonlyBucket, ReadonlySingleton,
+    Singleton,
 };
 use cw_storage_plus::Item;
+
+pub static CONFIG_KEY: &[u8] = b"config";
 
 pub static TRANSFER_KEY: &[u8] = b"transfer";
 
@@ -26,7 +30,16 @@ pub struct Transfer {
     pub recipient: Addr,
 }
 
+// pub const CONFIG: Item<State> = Item::new(b"config".into());
 pub const CONFIG: Item<State> = Item::new("config");
+
+pub fn config(storage: &mut dyn Storage) -> Singleton<State> {
+    singleton(storage, CONFIG_KEY)
+}
+
+pub fn config_read(storage: &dyn Storage) -> ReadonlySingleton<State> {
+    singleton_read(storage, CONFIG_KEY)
+}
 
 pub fn get_transfer_storage(storage: &mut dyn Storage) -> Bucket<Transfer> {
     bucket(storage, TRANSFER_KEY)
@@ -42,4 +55,62 @@ pub fn get_all_transfers(storage: &dyn Storage) -> Vec<Transfer> {
         .range(None, None, cosmwasm_std::Order::Ascending)
         .map(|pair| pair.unwrap().1)
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use cosmwasm_std::testing::mock_env;
+    use cw_storage_plus::Map;
+    use provwasm_mocks::mock_provenance_dependencies;
+
+    use super::*;
+
+    #[test]
+    fn migrate_test() {
+        let mut deps = mock_provenance_dependencies();
+
+        if let Err(error) = config(&mut deps.storage).save(
+        &State {
+                name: "contract_name".into(),
+            },
+        )
+        {
+            panic!("unexpected error: {:?}", error)
+        }
+
+        assert_eq!(
+            config_read(&mut deps.storage).load().unwrap(),
+            CONFIG.load(&deps.storage).unwrap()
+        )
+    }
+
+    #[test]
+    fn bucket_test() {
+        let mut deps = mock_provenance_dependencies();
+
+        if let Err(error) = get_ask_storage(&mut deps.storage).save(
+            b"aaa",
+            &State {
+                name: "contract_name".into(),
+            }
+        ) {
+            panic!("unexpected error: {:?}", error)
+        }
+
+        const ASKS_V1: Map<&[u8], State> = Map::new("asks");
+
+
+        assert_eq!(
+            get_ask_storage_read(&mut deps.storage).load(b"aaa").unwrap(),
+            ASKS_V1.load(&deps.storage, b"aaa").unwrap()
+        )
+    }
+
+    fn get_ask_storage(storage: &mut dyn Storage) -> Bucket<State> {
+        bucket(storage, b"asks")
+    }
+
+    pub fn get_ask_storage_read(storage: &dyn Storage) -> ReadonlyBucket<State> {
+        bucket_read(storage, b"asks")
+    }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,11 +3,9 @@ use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{Addr, Storage, Uint128};
 use cosmwasm_storage::{
-    bucket, bucket_read, singleton, singleton_read, Bucket, ReadonlyBucket, ReadonlySingleton,
-    Singleton,
+    bucket, bucket_read, Bucket, ReadonlyBucket,
 };
-
-pub static CONFIG_KEY: &[u8] = b"config";
+use cw_storage_plus::Item;
 
 pub static TRANSFER_KEY: &[u8] = b"transfer";
 
@@ -28,13 +26,7 @@ pub struct Transfer {
     pub recipient: Addr,
 }
 
-pub fn config(storage: &mut dyn Storage) -> Singleton<State> {
-    singleton(storage, CONFIG_KEY)
-}
-
-pub fn config_read(storage: &dyn Storage) -> ReadonlySingleton<State> {
-    singleton_read(storage, CONFIG_KEY)
-}
+pub const CONFIG: Item<State> = Item::new("config");
 
 pub fn get_transfer_storage(storage: &mut dyn Storage) -> Bucket<Transfer> {
     bucket(storage, TRANSFER_KEY)


### PR DESCRIPTION
# Problem 
[cosmwasm_storage](https://github.com/CosmWasm/cosmwasm/blob/main/packages/storage/src/singleton.rs#L10) is now deprecated

# Solution

Replace cosmwasm_storage with [cw_storage_plus](https://github.com/CosmWasm/cw-storage-plus/). There was a need to implement a contract migration given the difference in keys for `Singleton` vs `Item`.
