### PR TITLE
bump major version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "restricted-marker-transfer"
-version = "0.3.0"
+version = "1.0.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,9 +1078,9 @@ checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "uuid"
-version = "0.8.2"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ semver = "1.0.16"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0.64"
 thiserror = { version = "1.0" }
-uuid = { version= "0.8.2" }
+uuid = { version= "1.4.1" }
 
 [dev-dependencies]
 prost = {version = "0.11.0", default-features = false}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "restricted-marker-transfer"
-version = "0.3.0"
+version = "1.0.0"
 authors = ["Jason Talis <jtalis@figure.com>"]
 edition = "2018"
 

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -120,7 +120,7 @@ mod tests {
     #[test]
     fn test_migrate_invalid_version() {
         let mut deps = mock_provenance_dependencies();
-        let current_version: String = "1.1.0".into();
+        let current_version: String = "999.0.0".into();
         let new_version: String = String::from(PACKAGE_VERSION);
 
         set_contract_version(deps.as_mut().storage, CRATE_NAME, current_version).unwrap();

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -120,7 +120,7 @@ mod tests {
     #[test]
     fn test_migrate_invalid_version() {
         let mut deps = mock_provenance_dependencies();
-        let current_version: String = "0.4.0".into();
+        let current_version: String = "1.1.0".into();
         let new_version: String = String::from(PACKAGE_VERSION);
 
         set_contract_version(deps.as_mut().storage, CRATE_NAME, current_version).unwrap();


### PR DESCRIPTION
## Change summary
- bumps project to 1.0.0. This should be on 1.0 given it has been stable and in use on mainnet for a long time. 
- applying rennovate change to bump uuid crate version#12 


## Testing notes
- tested migrating an existing contract with open transfers and approving